### PR TITLE
Neo4jrb version up from 7.1.4 to 9.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .idea
 config.yml
 cache.db
-db/neo4j
+db/neo4j/*
+!db/neo4j/migrate
 bitcoin2graphdb.log
 bitcoin2graphdb.pid

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ config.yml
 cache.db
 db/neo4j/*
 !db/neo4j/migrate
+!db/neo4j/schema.yml
 bitcoin2graphdb.log
 bitcoin2graphdb.pid

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,15 @@ rvm:
 bundler_args: --jobs=2
 
 before_script:
-  - bundle exec rake neo4j:install[community-2.3.3,test]
+  - bundle exec rake neo4j:install[community-3.4.1,test]
   - bundle exec rake neo4j:config[test,7475]
   - bundle exec rake neo4j:start[test]
+  - sleep 20
+  - bundle exec rake neo4j:migrate
+
+env:
+  global:
+    - NEO4J_URL="http://localhost:7475"
 
 script:
   - bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Others are the same as normal rspec.
 ### install test database
 
 ```
-$ rake neo4j:install'[community-2.3.3,test]'
+$ rake neo4j:install'[community-3.4.1,test]'
 ```
 
 ### change port
@@ -122,6 +122,16 @@ $ rake neo4j:config'[test,7475]'
 
 ```
 $ rake neo4j:start'[test]'
+```
+
+### migration
+```
+$ rake neo4j:migrate
+```
+
+#### specify neo4j url (optional)
+```
+$ rake neo4j:migrate NEO4J_URL=http://localhost:7475
 ```
 
 ## Contributing

--- a/bitcoin2graphdb.gemspec
+++ b/bitcoin2graphdb.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "octorelease"
 
 end

--- a/bitcoin2graphdb.gemspec
+++ b/bitcoin2graphdb.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "openassets-ruby", ">= 0.6.5"
   spec.add_runtime_dependency "daemon-spawn"
-  spec.add_runtime_dependency "neo4j", "~>7.1.0"
+  spec.add_runtime_dependency "neo4j", "~>9.4.0"
+  spec.add_runtime_dependency "neo4j-rake_tasks"
   spec.add_runtime_dependency "activesupport", ">= 4.0.2"
   spec.add_runtime_dependency "thor"
 

--- a/db/neo4j/migrate/20190306081251_force_create_graphdb_model_active_node_base_uuid_constraint.rb
+++ b/db/neo4j/migrate/20190306081251_force_create_graphdb_model_active_node_base_uuid_constraint.rb
@@ -1,0 +1,9 @@
+class ForceCreateGraphdbModelActiveNodeBaseUuidConstraint < Neo4j::Migrations::Base
+  def up
+    add_constraint :"Graphdb::Model::ActiveNodeBase", :uuid, force: true
+  end
+
+  def down
+    drop_constraint :"Graphdb::Model::ActiveNodeBase", :uuid
+  end
+end

--- a/db/neo4j/migrate/20190306081322_force_create_graphdb_model_address_address_index.rb
+++ b/db/neo4j/migrate/20190306081322_force_create_graphdb_model_address_address_index.rb
@@ -1,0 +1,9 @@
+class ForceCreateGraphdbModelAddressAddressIndex < Neo4j::Migrations::Base
+  def up
+    add_index :"Graphdb::Model::Address", :address, force: true
+  end
+
+  def down
+    drop_index :"Graphdb::Model::Address", :address
+  end
+end

--- a/db/neo4j/migrate/20190306081338_force_create_graphdb_model_block_block_hash_index.rb
+++ b/db/neo4j/migrate/20190306081338_force_create_graphdb_model_block_block_hash_index.rb
@@ -1,0 +1,9 @@
+class ForceCreateGraphdbModelBlockBlockHashIndex < Neo4j::Migrations::Base
+  def up
+    add_index :"Graphdb::Model::Block", :block_hash, force: true
+  end
+
+  def down
+    drop_index :"Graphdb::Model::Block", :block_hash
+  end
+end

--- a/db/neo4j/migrate/20190306081351_force_create_graphdb_model_asset_id_asset_id_index.rb
+++ b/db/neo4j/migrate/20190306081351_force_create_graphdb_model_asset_id_asset_id_index.rb
@@ -1,0 +1,9 @@
+class ForceCreateGraphdbModelAssetIdAssetIdIndex < Neo4j::Migrations::Base
+  def up
+    add_index :"Graphdb::Model::AssetId", :asset_id, force: true
+  end
+
+  def down
+    drop_index :"Graphdb::Model::AssetId", :asset_id
+  end
+end

--- a/db/neo4j/migrate/20190306081404_force_create_graphdb_model_transaction_txid_index.rb
+++ b/db/neo4j/migrate/20190306081404_force_create_graphdb_model_transaction_txid_index.rb
@@ -1,0 +1,9 @@
+class ForceCreateGraphdbModelTransactionTxidIndex < Neo4j::Migrations::Base
+  def up
+    add_index :"Graphdb::Model::Transaction", :txid, force: true
+  end
+
+  def down
+    drop_index :"Graphdb::Model::Transaction", :txid
+  end
+end

--- a/db/neo4j/schema.yml
+++ b/db/neo4j/schema.yml
@@ -1,0 +1,29 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of ActiveNode to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.yml definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using neo4j:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+---
+:constraints:
+- CONSTRAINT ON ( `graphdb::model::activenodebase`:`Graphdb::Model::ActiveNodeBase`
+  ) ASSERT `graphdb::model::activenodebase`.uuid IS UNIQUE
+- CONSTRAINT ON ( `neo4j::migrations::schemamigration`:`Neo4j::Migrations::SchemaMigration`
+  ) ASSERT `neo4j::migrations::schemamigration`.migration_id IS UNIQUE
+:indexes:
+- INDEX ON :Graphdb::Model::Address(address)
+- INDEX ON :Graphdb::Model::AssetId(asset_id)
+- INDEX ON :Graphdb::Model::Block(block_hash)
+- INDEX ON :Graphdb::Model::Transaction(txid)
+:versions:
+- '20190306081251'
+- '20190306081322'
+- '20190306081338'
+- '20190306081351'
+- '20190306081404'

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -1,3 +1,4 @@
 require 'active_support/all'
 require 'bitcoin2graphdb'
 require 'graphdb'
+require 'neo4j/core/cypher_session/adaptors/http'

--- a/lib/bitcoin2graphdb/migration.rb
+++ b/lib/bitcoin2graphdb/migration.rb
@@ -26,7 +26,7 @@ module Bitcoin2Graphdb
 
     def run_with_height(block_height)
       puts "start migration for block height = #{block_height}. #{Time.now}"
-      Neo4j::Transaction.run do |tx|
+      Neo4j::ActiveBase.run_transaction do |tx|
         begin
           Graphdb::Model::Block.create_from_block_height(block_height)
           @block_height = block_height
@@ -44,7 +44,7 @@ module Bitcoin2Graphdb
     end
 
     def repair_assign_txs(block_height)
-      Neo4j::Transaction.run do |tx|
+      Neo4j::ActiveBase.run_transaction do |tx|
         begin
           block = Graphdb::Model::Block.with_height(block_height).first
           if block
@@ -67,7 +67,7 @@ module Bitcoin2Graphdb
     end
 
     def remove_block(block_height)
-      Neo4j::Transaction.run do |tx|
+      Neo4j::ActiveBase.run_transaction do |tx|
         begin
           block = Graphdb::Model::Block.with_height(block_height).first
           if block.nil?
@@ -84,7 +84,7 @@ module Bitcoin2Graphdb
     end
 
     def import_tx(txid)
-      Neo4j::Transaction.run do |tx|
+      Neo4j::ActiveBase.run_transaction do |tx|
         begin
           tx = Graphdb::Model::Transaction.with_txid(txid).first
           if tx.nil?
@@ -101,7 +101,7 @@ module Bitcoin2Graphdb
     end
 
     def remove_tx(txid)
-      Neo4j::Transaction.run do |tx|
+      Neo4j::ActiveBase.run_transaction do |tx|
         begin
           tx = Graphdb::Model::Transaction.with_txid(txid).first
           if tx.nil?

--- a/lib/bitcoin2graphdb/migration.rb
+++ b/lib/bitcoin2graphdb/migration.rb
@@ -11,7 +11,8 @@ module Bitcoin2Graphdb
       end
       neo4j_config = {basic_auth: config[:neo4j][:basic_auth], initialize: neo4j_timeout_ops(config)}
       Bitcoin2Graphdb::Bitcoin.provider = Bitcoin2Graphdb::Bitcoin::BlockchainProvider.new(config[:bitcoin])
-      Neo4j::Session.open(:server_db, config[:neo4j][:server], neo4j_config)
+      neo4j_adaptor = Neo4j::Core::CypherSession::Adaptors::HTTP.new(config[:neo4j][:server], neo4j_config)
+      Neo4j::ActiveBase.on_establish_session { Neo4j::Core::CypherSession.new(neo4j_adaptor) }
       @sleep_interval = config[:bitcoin][:sleep_interval].nil? ? 600 : config[:bitcoin][:sleep_interval].to_i
 
       Graphdb::Model.constants.each {|const_name| Graphdb::Model.const_get(const_name)}

--- a/lib/graphdb/model/address.rb
+++ b/lib/graphdb/model/address.rb
@@ -1,7 +1,7 @@
 module Graphdb
   module Model
     class Address < ActiveNodeBase
-      property :address, index: :exact
+      property :address
 
       has_many :in, :outputs, origin: :addresses, model_class: 'Graphdb::Model::TxOut'
 

--- a/lib/graphdb/model/block.rb
+++ b/lib/graphdb/model/block.rb
@@ -2,7 +2,7 @@ module Graphdb
   module Model
     class Block < ActiveNodeBase
 
-      property :block_hash, index: :exact
+      property :block_hash
       property :size, type: Integer
       property :height, type: Integer
       property :version

--- a/lib/graphdb/model/extensions/open_assets/asset_id.rb
+++ b/lib/graphdb/model/extensions/open_assets/asset_id.rb
@@ -2,7 +2,7 @@ module Graphdb
   module Model
 
     class AssetId < ActiveNodeBase
-      property :asset_id, index: :exact
+      property :asset_id
 
       has_many :in, :outputs, origin: :asset_id, model_class: 'Graphdb::Model::TxOut'
 

--- a/lib/graphdb/model/transaction.rb
+++ b/lib/graphdb/model/transaction.rb
@@ -3,7 +3,7 @@ module Graphdb
     class Transaction < ActiveNodeBase
 
       property :hex
-      property :txid, index: :exact
+      property :txid
       property :version, type: Integer
       property :lock_time
       property :block_hash

--- a/spec/bitcoin2graphdb/migration_spec.rb
+++ b/spec/bitcoin2graphdb/migration_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Bitcoin2Graphdb::Migration do
+describe Bitcoin2Graphdb::Migration, migration: true do
 
   describe 'load configuration' do
     context 'default configuration' do

--- a/spec/graphdb/model/extensions/open_assets/asset_id_spec.rb
+++ b/spec/graphdb/model/extensions/open_assets/asset_id_spec.rb
@@ -1,11 +1,6 @@
 require 'spec_helper'
-require 'graphdb/model/extensions/open_assets/asset_id'
-describe Graphdb::Model::AssetId do
 
-  before{
-    Graphdb::Model::Transaction.prepend(Graphdb::Model::Extensions::OpenAssets::Transaction)
-    Graphdb::Model::TxOut.prepend(Graphdb::Model::Extensions::OpenAssets::TxOut)
-  }
+describe 'Graphdb::Model::AssetId' do
 
   describe 'with asset_id scope' do
     before {

--- a/spec/graphdb/model/extensions/open_assets/transaction_spec.rb
+++ b/spec/graphdb/model/extensions/open_assets/transaction_spec.rb
@@ -2,11 +2,6 @@ require 'spec_helper'
 
 describe 'Graphdb::Model::Extensions::OpenAssets::Transaction' do
 
-  before{
-    Graphdb::Model::Transaction.prepend(Graphdb::Model::Extensions::OpenAssets::Transaction)
-    Graphdb::Model::TxOut.prepend(Graphdb::Model::Extensions::OpenAssets::TxOut)
-  }
-
   describe 'create oa transaction' do
     context 'not oa transaction' do
       subject{

--- a/spec/graphdb/model/extensions/open_assets/tx_out_spec.rb
+++ b/spec/graphdb/model/extensions/open_assets/tx_out_spec.rb
@@ -2,11 +2,6 @@ require 'spec_helper'
 
 describe 'Graphdb::Model::Extensions::OpenAssets::TxOut' do
 
-  before{
-    Graphdb::Model::Transaction.prepend(Graphdb::Model::Extensions::OpenAssets::Transaction)
-    Graphdb::Model::TxOut.prepend(Graphdb::Model::Extensions::OpenAssets::TxOut)
-  }
-
   describe 'output coloring' do
     before{
       Graphdb::Model::Transaction.create_from_txid('525f7baa656d04016fad0094187cc969b526ca1261312ddf09a648d822ee6cdd')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,12 @@ RSpec.configure do |config|
     neo4j_session
     unless example.metadata[:cli]
       setup_mock
-      Graphdb.configuration.unload_extensions
+      unless example.metadata[:migration]
+        Graphdb.configure do |config|
+          config.neo4j_server = 'http://localhost:7475'
+          config.extensions = ['open_assets']
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,15 @@
 require 'rubygems'
 require 'base'
-require 'database_cleaner'
 require 'bitcoin_mock'
 require 'neo4j/core/cypher_session/adaptors/http'
 
 RSpec.configure do |config|
 
-  DatabaseCleaner[:neo4j, connection: {type: :server_db, path: 'http://localhost:7475'}].strategy = :transaction
   include BitcoinMock
 
   config.before(:each) do |example|
     neo4j_session
     unless example.metadata[:cli]
-      DatabaseCleaner.start
       setup_mock
       Graphdb.configuration.unload_extensions
     end
@@ -24,7 +21,7 @@ RSpec.configure do |config|
         File.delete f
       end
     else
-      DatabaseCleaner.clean
+      Neo4j::ActiveBase.current_session.query('MATCH(n) DETACH DELETE n')
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'base'
 require 'database_cleaner'
 require 'bitcoin_mock'
-require 'neo4j'
+require 'neo4j/core/cypher_session/adaptors/http'
 
 RSpec.configure do |config|
 
@@ -10,6 +10,7 @@ RSpec.configure do |config|
   include BitcoinMock
 
   config.before(:each) do |example|
+    neo4j_session
     unless example.metadata[:cli]
       DatabaseCleaner.start
       setup_mock
@@ -45,4 +46,9 @@ end
 def fixture_file(relative_path)
   file = File.read(File.join(File.dirname(__FILE__), 'fixtures', relative_path))
   JSON.parse(file)
+end
+
+def neo4j_session
+  neo4j_adaptor = Neo4j::Core::CypherSession::Adaptors::HTTP.new('http://localhost:7475', { :basic_auth => { username: 'neo4j', password: 'neo4j' }, :initialize => { :request => {:timeout => 600, :open_timeout => 2}}})
+  Neo4j::ActiveBase.on_establish_session { Neo4j::Core::CypherSession.new(neo4j_adaptor) }
 end


### PR DESCRIPTION
- Update neo4jrb.
- Fix how to open neo4j session.
- Delete for nodes should use query `MATCH(n) DETACH DELETE n`. DatabaseCleaner is not support neo4jrb 9.4.0.
- Has_n define should be once. Fix load lib order in spec.
- Fix how to call transaction. Transaction must use `Neo4j::ActiveBase.run_transaction`.
- Index removed. Property option `index` will be no longer support. Index must generate schema and migrate.
- Add build settings for travis.