### PR TITLE
Performance improved by fixing slow logics. 

### DIFF
--- a/lib/graphdb/model/extensions/open_assets/transaction.rb
+++ b/lib/graphdb/model/extensions/open_assets/transaction.rb
@@ -32,9 +32,8 @@ module Graphdb
 
           def apply_oa_outputs
             oa_outputs = Bitcoin2Graphdb::Bitcoin.provider.oa_outputs(txid)
-            graph_outputs = outputs.to_a
             oa_outputs.each{|o|
-              output = graph_outputs.find{|graph_out|graph_out.n == o['vout']}
+              output = outputs.find_by(n: o['vout'])
               output.apply_oa_attributes(o)
             }
           end

--- a/lib/graphdb/model/extensions/open_assets/transaction.rb
+++ b/lib/graphdb/model/extensions/open_assets/transaction.rb
@@ -32,10 +32,12 @@ module Graphdb
 
           def apply_oa_outputs
             oa_outputs = Bitcoin2Graphdb::Bitcoin.provider.oa_outputs(txid)
-            oa_outputs.each{|o|
-              output = outputs.find_by(n: o['vout'])
-              output.apply_oa_attributes(o)
-            }
+            if oa_outputs.any?{ |tx_out| tx_out['output_type'] == 'marker' }
+              oa_outputs.each{|o|
+                output = outputs.find_by(n: o['vout'])
+                output.apply_oa_attributes(o)
+              }
+            end
           end
 
         end

--- a/lib/graphdb/model/extensions/open_assets/tx_out.rb
+++ b/lib/graphdb/model/extensions/open_assets/tx_out.rb
@@ -10,8 +10,8 @@ module Graphdb
 
             end
             base.class_eval do
-              property :asset_quantity, type: Integer
-              property :oa_output_type
+              property :asset_quantity, type: Integer, default: 0
+              property :oa_output_type, default: 'uncolored'
               has_one :out, :asset_id, type: :asset_id, model_class: 'Graphdb::Model::AssetId'
             end
           end

--- a/lib/graphdb/model/tx_out.rb
+++ b/lib/graphdb/model/tx_out.rb
@@ -41,9 +41,7 @@ module Graphdb
       def self.find_by_outpoint(txid, n)
         tx = Graphdb::Model::Transaction.with_txid(txid).first
         if tx
-          tx.outputs.each{|o|
-            return o if o.n == n
-          }
+          tx.outputs.find_by(n: n)
         end
       end
 


### PR DESCRIPTION
This pull request is for performance improvement.

The library ever had some performance issue.
I profile the block import logics.
I found two logic have performance issue.

1. [`Graphdb::Model::Extensions::OpenAssets::Transaction#apply_oa_outputs`](https://github.com/haw-itn/bitcoin2graphdb/blob/bc6aa44d9c2600aabe6ab1649f90fd03cefeac1f/lib/graphdb/model/extensions/open_assets/transaction.rb#L36)
There is use `Array#find` in `Array#each`. It is slow logic.

2. [`Graphdb::Model::TxOut.find_by_outpoint`](https://github.com/haw-itn/bitcoin2graphdb/blob/bc6aa44d9c2600aabe6ab1649f90fd03cefeac1f/lib/graphdb/model/tx_out.rb#L44)
`Array#each` run until finding transaction. It is very slow logic when it has many transaction outputs.


Thease are faster by using `ActiveNode::Base.find_by`. I fixed.
Please review my fixes and merge. Thanks.
